### PR TITLE
bug: Corrected SHA256 for v2.13.0

### DIFF
--- a/komac.rb
+++ b/komac.rb
@@ -7,7 +7,7 @@ class Komac < Formula
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-x86_64-apple-darwin.tar.gz"
-      sha256 "sha256:ea872d5ca91446f889fdd52aeaaca578642783ad38f9323e911b1490a842545f"
+      sha256 "ea872d5ca91446f889fdd52aeaaca578642783ad38f9323e911b1490a842545f"
 
       def install
         bin.install "komac"
@@ -15,7 +15,7 @@ class Komac < Formula
     end
     if Hardware::CPU.arm?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-aarch64-apple-darwin.tar.gz"
-      sha256 "sha256:992d3294d1483dd54c110a24895e91a202cfaab1a2467440a4e4f5f46f511540"
+      sha256 "992d3294d1483dd54c110a24895e91a202cfaab1a2467440a4e4f5f46f511540"
 
       def install
         bin.install "komac"
@@ -26,7 +26,7 @@ class Komac < Formula
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "sha256:463e95ebeb9dd0338e5dec696aa3325fbfbec69a61a7991c497eeda077cfeb80"
+      sha256 "463e95ebeb9dd0338e5dec696aa3325fbfbec69a61a7991c497eeda077cfeb80"
 
       def install
         bin.install "komac"
@@ -34,7 +34,7 @@ class Komac < Formula
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "sha256:912c212d62b1f13f9808b67d49ab36382e7c813eb64d53390840fe5473765e00"
+      sha256 "912c212d62b1f13f9808b67d49ab36382e7c813eb64d53390840fe5473765e00"
 
       def install
         bin.install "komac"

--- a/komac.rb
+++ b/komac.rb
@@ -7,7 +7,7 @@ class Komac < Formula
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-x86_64-apple-darwin.tar.gz"
-      sha256 "Not"
+      sha256 "sha256:ea872d5ca91446f889fdd52aeaaca578642783ad38f9323e911b1490a842545f"
 
       def install
         bin.install "komac"
@@ -15,7 +15,7 @@ class Komac < Formula
     end
     if Hardware::CPU.arm?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-aarch64-apple-darwin.tar.gz"
-      sha256 "Not"
+      sha256 "sha256:992d3294d1483dd54c110a24895e91a202cfaab1a2467440a4e4f5f46f511540"
 
       def install
         bin.install "komac"
@@ -26,7 +26,7 @@ class Komac < Formula
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "Not"
+      sha256 "sha256:463e95ebeb9dd0338e5dec696aa3325fbfbec69a61a7991c497eeda077cfeb80"
 
       def install
         bin.install "komac"
@@ -34,7 +34,7 @@ class Komac < Formula
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/russellbanks/Komac/releases/download/v2.13.0/komac-2.13.0-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "Not"
+      sha256 "sha256:912c212d62b1f13f9808b67d49ab36382e7c813eb64d53390840fe5473765e00"
 
       def install
         bin.install "komac"


### PR DESCRIPTION
Updated all the SHA256 as they were incorrect from the previous logic since the sha256 files were not created in the actual release of komac.

Resolves: https://github.com/russellbanks/homebrew-tap/issues/2