### PR TITLE
chore: Update SHA256 updating logic

### DIFF
--- a/.github/workflows/komac.yml
+++ b/.github/workflows/komac.yml
@@ -13,18 +13,42 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download files, calculate hashes, and update formula
         run: |
-          # Update the version in the formula
-          (Get-Content -Raw ./komac.rb.template).Replace('<VERSION>','${{ github.event.inputs.version }}') | Out-File -NoNewline ./komac.rb
-
-          # Update sha256 hashes
-          (Get-Content -Raw ./komac.rb | Select-String -Pattern '(?<=sha256\s").*(?=")' -AllMatches).Matches.Value | ForEach-Object {
-            (Get-Content -Raw ./komac.rb).Replace($_, $(curl -sL $_ | awk '{print $1}')) | Out-File -NoNewline ./komac.rb
-          }
-
+          VERSION="${{ github.event.inputs.version }}"
+          
+          # Create URLs for the release files
+          BASE_URL="https://github.com/russellbanks/Komac/releases/download/v${VERSION}"
+          MACOS_INTEL_URL="${BASE_URL}/komac-${VERSION}-x86_64-apple-darwin.tar.gz"
+          MACOS_ARM_URL="${BASE_URL}/komac-${VERSION}-aarch64-apple-darwin.tar.gz"
+          LINUX_INTEL_URL="${BASE_URL}/komac-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          LINUX_ARM_URL="${BASE_URL}/komac-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+          
+          # Download files and calculate SHA256 hashes
+          echo "Downloading and calculating hashes..."
+          MACOS_INTEL_SHA256=$(curl -sL "$MACOS_INTEL_URL" | shasum -a 256 | cut -d' ' -f1)
+          MACOS_ARM_SHA256=$(curl -sL "$MACOS_ARM_URL" | shasum -a 256 | cut -d' ' -f1)
+          LINUX_INTEL_SHA256=$(curl -sL "$LINUX_INTEL_URL" | shasum -a 256 | cut -d' ' -f1)
+          LINUX_ARM_SHA256=$(curl -sL "$LINUX_ARM_URL" | shasum -a 256 | cut -d' ' -f1)
+          
+          echo "SHA256 hashes calculated:"
+          echo "macOS Intel: $MACOS_INTEL_SHA256"
+          echo "macOS ARM: $MACOS_ARM_SHA256"
+          echo "Linux Intel: $LINUX_INTEL_SHA256"
+          echo "Linux ARM: $LINUX_ARM_SHA256"
+          
+          # Update the formula from template
+          cp ./komac.rb.template ./komac.rb
+          
+          # Replace placeholders with actual values
+          sed -i '' "s/<VERSION>/${VERSION}/g" ./komac.rb
+          sed -i '' "s/<SHA256_MACOS_INTEL>/${MACOS_INTEL_SHA256}/g" ./komac.rb
+          sed -i '' "s/<SHA256_MACOS_ARM>/${MACOS_ARM_SHA256}/g" ./komac.rb
+          sed -i '' "s/<SHA256_LINUX_INTEL>/${LINUX_INTEL_SHA256}/g" ./komac.rb
+          sed -i '' "s/<SHA256_LINUX_ARM>/${LINUX_ARM_SHA256}/g" ./komac.rb
+          
           # Commit and push changes
           git config --local user.name "github-actions[bot]"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add komac.rb
-          git commit -m "Update komac to v${{ github.event.inputs.version }}"
+          git commit -m "Update komac to v${VERSION}"
           git push
-        shell: pwsh
+        shell: bash

--- a/.github/workflows/komac.yml
+++ b/.github/workflows/komac.yml
@@ -11,25 +11,24 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Download files, calculate hashes, and update formula
+      - name: Fetch release asset hashes and update formula
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ github.event.inputs.version }}"
+          REPO="russellbanks/Komac"
           
-          # Create URLs for the release files
-          BASE_URL="https://github.com/russellbanks/Komac/releases/download/v${VERSION}"
-          MACOS_INTEL_URL="${BASE_URL}/komac-${VERSION}-x86_64-apple-darwin.tar.gz"
-          MACOS_ARM_URL="${BASE_URL}/komac-${VERSION}-aarch64-apple-darwin.tar.gz"
-          LINUX_INTEL_URL="${BASE_URL}/komac-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          LINUX_ARM_URL="${BASE_URL}/komac-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+          # Get asset info as JSON from GitHub
+          echo "Fetching release assets for v${VERSION}..."
+          ASSETS_JSON=$(gh release view --repo "$REPO" "v$VERSION" --json assets)
           
-          # Download files and calculate SHA256 hashes
-          echo "Downloading and calculating hashes..."
-          MACOS_INTEL_SHA256=$(curl -sL "$MACOS_INTEL_URL" | shasum -a 256 | cut -d' ' -f1)
-          MACOS_ARM_SHA256=$(curl -sL "$MACOS_ARM_URL" | shasum -a 256 | cut -d' ' -f1)
-          LINUX_INTEL_SHA256=$(curl -sL "$LINUX_INTEL_URL" | shasum -a 256 | cut -d' ' -f1)
-          LINUX_ARM_SHA256=$(curl -sL "$LINUX_ARM_URL" | shasum -a 256 | cut -d' ' -f1)
+          # Extract SHA256 for each asset using jq (remove sha256: prefix)
+          MACOS_INTEL_SHA256=$(echo "$ASSETS_JSON" | jq -r '.assets[] | select(.name | test("x86_64-apple-darwin.tar.gz$")) | .digest' | sed 's/sha256://')
+          MACOS_ARM_SHA256=$(echo "$ASSETS_JSON" | jq -r '.assets[] | select(.name | test("aarch64-apple-darwin.tar.gz$")) | .digest' | sed 's/sha256://')
+          LINUX_INTEL_SHA256=$(echo "$ASSETS_JSON" | jq -r '.assets[] | select(.name | test("x86_64-unknown-linux-gnu.tar.gz$")) | .digest' | sed 's/sha256://')
+          LINUX_ARM_SHA256=$(echo "$ASSETS_JSON" | jq -r '.assets[] | select(.name | test("aarch64-unknown-linux-gnu.tar.gz$")) | .digest' | sed 's/sha256://')
           
-          echo "SHA256 hashes calculated:"
+          echo "SHA256 hashes fetched from GitHub:"
           echo "macOS Intel: $MACOS_INTEL_SHA256"
           echo "macOS ARM: $MACOS_ARM_SHA256"
           echo "Linux Intel: $LINUX_INTEL_SHA256"

--- a/komac.rb.template
+++ b/komac.rb.template
@@ -7,7 +7,7 @@ class Komac < Formula
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-x86_64-apple-darwin.tar.gz"
-      sha256 "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-x86_64-apple-darwin.tar.gz.sha256"
+      sha256 "<SHA256_MACOS_INTEL>"
 
       def install
         bin.install "komac"
@@ -15,7 +15,7 @@ class Komac < Formula
     end
     if Hardware::CPU.arm?
       url "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-aarch64-apple-darwin.tar.gz"
-      sha256 "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-aarch64-apple-darwin.tar.gz.sha256"
+      sha256 "<SHA256_MACOS_ARM>"
 
       def install
         bin.install "komac"
@@ -26,7 +26,7 @@ class Komac < Formula
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-x86_64-unknown-linux-gnu.tar.gz.sha256"
+      sha256 "<SHA256_LINUX_INTEL>"
 
       def install
         bin.install "komac"
@@ -34,7 +34,7 @@ class Komac < Formula
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "https://github.com/russellbanks/Komac/releases/download/v<VERSION>/komac-<VERSION>-aarch64-unknown-linux-gnu.tar.gz.sha256"
+      sha256 "<SHA256_LINUX_ARM>"
 
       def install
         bin.install "komac"


### PR DESCRIPTION
This PR updates the logic of how the SHA256 logic updates. Instead of using sha256 files from the Komac release, this downloads the file and calculates the sha256, and therefore this should always work.

Feel free to close this PR if you do not agree with any of the changes :)